### PR TITLE
Refine login accessibility feedback

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,43 +1,112 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Iniciar sesión · EduPlay</title>
     <style>
         body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#0f172a;color:#e2e8f0}
         .wrap{max-width:420px;margin:10vh auto;padding:24px}
-        form{display:grid;gap:12px;background:#111827;border:1px solid #1f2937;border-radius:16px;padding:20px}
+        form{display:grid;gap:16px;background:#111827;border:1px solid #1f2937;border-radius:16px;padding:20px}
+        .field{display:flex;flex-direction:column;gap:6px}
+        label{font-size:14px;color:#cbd5f5;letter-spacing:.01em}
         input{padding:10px;border-radius:10px;border:1px solid #374151;background:#0b1220;color:#e5e7eb}
-        button{padding:12px;border-radius:10px;border:0;background:#2563eb;color:#fff;cursor:pointer}
-        .err{color:#fca5a5}
+        button{padding:12px;border-radius:10px;border:0;background:#2563eb;color:#fff;cursor:pointer;transition:background .2s}
+        button[disabled]{opacity:.6;cursor:wait}
+        .err{color:#fca5a5;min-height:1.2em;outline:none}
+        .register{font-size:14px;text-align:center;color:#cbd5f5}
+        .register a{color:#60a5fa}
     </style>
 </head>
 <body>
 <div class="wrap">
     <h2>Acceder</h2>
     <form id="f">
-        <input name="username" placeholder="Usuario" required />
-        <input name="password" placeholder="Contraseña" type="password" required />
-        <button>Entrar</button>
-        <div class="err" id="e"></div>
+        <div class="field">
+            <label for="username">Usuario</label>
+            <input id="username" name="username" type="text" placeholder="Introduce tu usuario" autocomplete="username" aria-describedby="login-status" required>
+        </div>
+        <div class="field">
+            <label for="password">Contraseña</label>
+            <input id="password" name="password" type="password" placeholder="Introduce tu contraseña" autocomplete="current-password" aria-describedby="login-status" required>
+        </div>
+        <button type="submit">Entrar</button>
+        <p class="err" id="login-status" role="alert" aria-live="assertive" aria-atomic="true" tabindex="-1">Introduce tus credenciales para acceder.</p>
+        <p class="register">¿Aún no tienes cuenta? <a href="/registro">Regístrate aquí</a>.</p>
     </form>
 </div>
 <script>
-    const f = document.getElementById('f'), e = document.getElementById('e');
+    const f = document.getElementById('f');
+    const statusEl = document.getElementById('login-status');
+    const submitBtn = f.querySelector('button[type="submit"]');
+
+    const setStatus = (message, { focus = true } = {}) => {
+        statusEl.textContent = message;
+        if (focus) {
+            statusEl.focus({ preventScroll: true });
+        }
+    };
+
+    const enableSubmit = () => {
+        submitBtn.disabled = false;
+        submitBtn.removeAttribute('aria-busy');
+    };
+
+    const disableSubmit = () => {
+        submitBtn.disabled = true;
+        submitBtn.setAttribute('aria-busy', 'true');
+    };
+
     f.addEventListener('submit', async (ev) => {
         ev.preventDefault();
-        e.textContent = '';
+        disableSubmit();
+        setStatus('Enviando credenciales...', { focus: false });
         const fd = new FormData(f);
         const body = { username: fd.get('username'), password: fd.get('password') };
-        const res = await fetch('/api/login', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-            credentials: 'include'
-        });
-        if (res.ok) location.href = '/app/';
-        else e.textContent = (await res.text()) || 'Usuario o contraseña incorrectos';
+        let redirecting = false;
+        try {
+            const res = await fetch('/api/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+                credentials: 'include'
+            });
+            if (res.ok) {
+                setStatus('Acceso concedido, redirigiendo…');
+                redirecting = true;
+                setTimeout(() => {
+                    location.href = '/app/';
+                }, 300);
+                return;
+            }
+
+            const rawMessage = await res.text();
+            let message = rawMessage.trim();
+
+            if (rawMessage) {
+                try {
+                    const parsed = JSON.parse(rawMessage);
+                    if (parsed && typeof parsed.message === 'string' && parsed.message.trim()) {
+                        message = parsed.message.trim();
+                    }
+                } catch (_) {
+                    // Ignorar: la respuesta no es JSON válido.
+                }
+            }
+
+            if (!message) {
+                message = 'Usuario o contraseña incorrectos.';
+            }
+
+            setStatus(message);
+        } catch (error) {
+            console.error('Error al iniciar sesión:', error);
+            setStatus('No se pudo conectar con el servicio. Revisa tu conexión e inténtalo de nuevo.');
+        } finally {
+            if (!redirecting) {
+                enableSubmit();
+            }
+        }
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- associate the login inputs with the shared alert region and expose it as a focusable assertive status message
- improve submission handling by toggling aria-busy, focusing updates, parsing server errors, and keeping the button disabled while redirecting
- adjust markup to satisfy html-validate recommendations, including explicit input types and uppercase doctype

## Testing
- npx --yes html-validate frontend/login.html

------
https://chatgpt.com/codex/tasks/task_b_68fe5eeefb08832aa9ff2b53f0493d84