### PR TITLE
Implement PBKDF2 password hashing for login/register

### DIFF
--- a/frontend/functions/api/login.js
+++ b/frontend/functions/api/login.js
@@ -1,16 +1,20 @@
+import { verifyPassword } from "../lib/auth";
+
 export const onRequestPost = async ({ request, env }) => {
     try {
         const { username, password } = await request.json();
         if (!username || !password) return new Response("Faltan credenciales", { status: 400 });
 
         // Buscar usuario en D1
-        const row = await env.DB.prepare("SELECT id, username, password FROM users WHERE username = ?")
+        const row = await env.DB.prepare(
+            "SELECT id, username, password_hash, password_salt, password_iterations, password_algo FROM users WHERE username = ?"
+        )
             .bind(username).first();
 
         if (!row) return new Response("Credenciales inválidas", { status: 401 });
 
-        // Comparación simple (Plano). ⚠️ Te paso nota para PBKDF2 abajo.
-        if (row.password !== password) return new Response("Credenciales inválidas", { status: 401 });
+        const ok = await verifyPassword(password, row);
+        if (!ok) return new Response("Credenciales inválidas", { status: 401 });
 
         // Crear token firmado (expira en 24h)
         const payload = { sub: row.id, u: row.username, exp: Math.floor(Date.now()/1000) + 60*60*24 };

--- a/frontend/functions/api/register.js
+++ b/frontend/functions/api/register.js
@@ -1,0 +1,46 @@
+import { hashPassword, toColumnTuple } from "../lib/auth";
+
+const CREATE_USERS_SQL = `
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    password_salt TEXT NOT NULL,
+    password_iterations INTEGER NOT NULL,
+    password_algo TEXT NOT NULL DEFAULT 'pbkdf2-sha256',
+    created_at TEXT DEFAULT (datetime('now'))
+)`;
+
+export const onRequestPost = async ({ request, env }) => {
+    try {
+        const { username, password } = await request.json();
+        if (typeof username !== "string" || typeof password !== "string") {
+            return new Response("Formato inválido", { status: 400 });
+        }
+        const trimmedUser = username.trim();
+        if (!trimmedUser || password.length < 8) {
+            return new Response("Usuario o contraseña inválidos", { status: 400 });
+        }
+
+        await env.DB.prepare(CREATE_USERS_SQL).run();
+
+        const existing = await env.DB.prepare("SELECT id FROM users WHERE username = ?")
+            .bind(trimmedUser)
+            .first();
+        if (existing) {
+            return new Response("Usuario ya registrado", { status: 409 });
+        }
+
+        const hashed = await hashPassword(password);
+        await env.DB.prepare(
+            "INSERT INTO users (username, password_hash, password_salt, password_iterations, password_algo) VALUES (?,?,?,?,?)"
+        )
+            .bind(trimmedUser, ...toColumnTuple(hashed))
+            .run();
+
+        return new Response("Creado", { status: 201 });
+    } catch (err) {
+        console.error("register", err);
+        return new Response("Error", { status: 500 });
+    }
+};

--- a/frontend/functions/lib/auth.js
+++ b/frontend/functions/lib/auth.js
@@ -1,0 +1,149 @@
+export const DEFAULT_ALGORITHM = "pbkdf2-sha256";
+export const DEFAULT_ITERATIONS = 100_000;
+const KEY_LENGTH = 32; // 256 bits
+
+/**
+ * Generates a secure random salt.
+ * @param {number} length Number of bytes.
+ * @returns {Uint8Array}
+ */
+export function generateSalt(length = 16) {
+    if (!Number.isInteger(length) || length <= 0) {
+        throw new TypeError("Salt length must be a positive integer");
+    }
+    const salt = new Uint8Array(length);
+    crypto.getRandomValues(salt);
+    return salt;
+}
+
+/**
+ * Derives a key using PBKDF2 (SHA-256).
+ * @param {string} password Plain password provided by user.
+ * @param {Uint8Array} salt Salt bytes.
+ * @param {number} iterations Number of iterations.
+ * @param {number} length Length of derived key in bytes.
+ * @returns {Promise<Uint8Array>} Derived key bytes.
+ */
+async function derivePbkdf2(password, salt, iterations, length = KEY_LENGTH) {
+    if (typeof password !== "string" || password.length === 0) {
+        throw new TypeError("Password must be a non-empty string");
+    }
+    if (!(salt instanceof Uint8Array)) {
+        throw new TypeError("Salt must be a Uint8Array");
+    }
+    if (!Number.isInteger(iterations) || iterations <= 0) {
+        throw new TypeError("Iterations must be a positive integer");
+    }
+
+    const encoder = new TextEncoder();
+    const keyMaterial = await crypto.subtle.importKey(
+        "raw",
+        encoder.encode(password),
+        "PBKDF2",
+        false,
+        ["deriveBits", "deriveKey"]
+    );
+
+    const derivedBits = await crypto.subtle.deriveBits(
+        {
+            name: "PBKDF2",
+            hash: "SHA-256",
+            salt,
+            iterations
+        },
+        keyMaterial,
+        length * 8
+    );
+
+    return new Uint8Array(derivedBits);
+}
+
+function toBase64(bytes) {
+    let binary = "";
+    bytes.forEach(b => binary += String.fromCharCode(b));
+    return btoa(binary);
+}
+
+function fromBase64(str) {
+    const binary = atob(str);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+function timingSafeEqual(a, b) {
+    if (!(a instanceof Uint8Array) || !(b instanceof Uint8Array)) {
+        throw new TypeError("timingSafeEqual expects Uint8Array arguments");
+    }
+
+    const len = Math.max(a.length, b.length);
+    let mismatch = a.length ^ b.length;
+    for (let i = 0; i < len; i++) {
+        const av = i < a.length ? a[i] : 0;
+        const bv = i < b.length ? b[i] : 0;
+        mismatch |= av ^ bv;
+    }
+    return mismatch === 0;
+}
+
+/**
+ * Hashes the password and returns persistent metadata.
+ * @param {string} password
+ * @param {{ iterations?: number, saltLength?: number }} [options]
+ */
+export async function hashPassword(password, options = {}) {
+    const iterations = options.iterations ?? DEFAULT_ITERATIONS;
+    const saltLength = options.saltLength ?? 16;
+    const salt = generateSalt(saltLength);
+    const hashBytes = await derivePbkdf2(password, salt, iterations);
+    return {
+        algorithm: DEFAULT_ALGORITHM,
+        iterations,
+        salt: toBase64(salt),
+        hash: toBase64(hashBytes)
+    };
+}
+
+/**
+ * Verifies if a password matches stored hash metadata.
+ * @param {string} password
+ * @param {{ password_hash?: string, password_salt?: string, password_iterations?: number, password_algo?: string, hash?: string, salt?: string, iterations?: number, algorithm?: string }} stored
+ */
+export async function verifyPassword(password, stored) {
+    if (!stored) return false;
+
+    const algorithm = (stored.password_algo || stored.algorithm || DEFAULT_ALGORITHM).toLowerCase();
+    if (algorithm !== DEFAULT_ALGORITHM) {
+        // Unknown algorithm; safest to reject.
+        return false;
+    }
+
+    const saltB64 = stored.password_salt || stored.salt;
+    const hashB64 = stored.password_hash || stored.hash;
+    const iterations = Number(stored.password_iterations || stored.iterations || 0);
+
+    if (!saltB64 || !hashB64 || !iterations) return false;
+
+    const saltBytes = fromBase64(saltB64);
+    const storedHash = fromBase64(hashB64);
+    const derived = await derivePbkdf2(password, saltBytes, iterations, storedHash.length);
+    return timingSafeEqual(derived, storedHash);
+}
+
+/**
+ * Helper to expose the metadata in column order for INSERT statements.
+ * @param {{ algorithm: string, iterations: number, salt: string, hash: string }} data
+ * @returns {Array}
+ */
+export function toColumnTuple(data) {
+    return [data.hash, data.salt, data.iterations, data.algorithm];
+}
+
+export function base64ToBytes(b64) {
+    return fromBase64(b64);
+}
+
+export function bytesToBase64(bytes) {
+    return toBase64(bytes);
+}

--- a/frontend/migrations/0001_users_secure.sql
+++ b/frontend/migrations/0001_users_secure.sql
@@ -1,0 +1,11 @@
+-- Recreate users table with salted password hashes.
+DROP TABLE IF EXISTS users;
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    password_salt TEXT NOT NULL,
+    password_iterations INTEGER NOT NULL,
+    password_algo TEXT NOT NULL DEFAULT 'pbkdf2-sha256',
+    created_at TEXT DEFAULT (datetime('now'))
+);

--- a/frontend/migrations/0002_seed_admin_user.sql
+++ b/frontend/migrations/0002_seed_admin_user.sql
@@ -1,0 +1,9 @@
+-- Seed default admin user with PBKDF2 hash for password "admin1234".
+INSERT INTO users (username, password_hash, password_salt, password_iterations, password_algo)
+VALUES (
+    'admin',
+    'XtMct1ezRn0//uhO90BxEvJKEGMMy7m7y9uck+9WL/w=',
+    'MZhMLe2EyJPrYTDhdc/1VQ==',
+    100000,
+    'pbkdf2-sha256'
+);


### PR DESCRIPTION
## Summary
- replace plaintext password comparison in the login worker with PBKDF2-based verification using a shared auth helper
- add a registration endpoint that hashes credentials with the same helper before persisting users
- recreate the users table schema and seed admin user data to store salt, hash, iteration count, and algorithm metadata

## Testing
- node - <<'EOF'
import { verifyPassword } from './frontend/functions/lib/auth.js';
const stored = {
  password_hash: 'XtMct1ezRn0//uhO90BxEvJKEGMMy7m7y9uck+9WL/w=',
  password_salt: 'MZhMLe2EyJPrYTDhdc/1VQ==',
  password_iterations: 100000,
  password_algo: 'pbkdf2-sha256'
};
const ok = await verifyPassword('admin1234', stored);
const fail = await verifyPassword('wrong', stored);
console.log('ok', ok, 'fail', fail);
EOF

------
https://chatgpt.com/codex/tasks/task_b_68fe5eefc1f0832abefc9b792bfb4b2d